### PR TITLE
Laads hotrelease

### DIFF
--- a/lasrc/README.md
+++ b/lasrc/README.md
@@ -87,3 +87,4 @@ After compiling the product-formatter raw\_binary libraries and tools, the conve
 3. Modified the LAADS update scripts to use the MODIS public http server -
    https://ladsweb.modaps.eosdis.nasa.gov instead of the ftp server
    ftp://ladssci.nascom.nasa.gov.
+4. Updated the application version number.

--- a/lasrc/README.md
+++ b/lasrc/README.md
@@ -1,5 +1,5 @@
-## LaSRC Version 1.0.1 Release Notes
-Release Date: March 2017
+## LaSRC Version 1.1.0 Release Notes
+Release Date: April 2017
 
 ### Downloads
 LaSRC (Landsat Surface Reflectance Code) source code
@@ -10,7 +10,7 @@ LaSRC auxiliary files
 
     http://edclpdsftp.cr.usgs.gov/downloads/auxiliaries/l8sr_auxiliary/l8sr_auxiliary.tar.gz
 
-See git tag [lasrc-version_1.0.1]
+See git tag [lasrc-version_1.1.0]
 
 ### Installation
   * Install dependent libraries - ESPA product formatter (https://github.com/USGS-EROS/espa-product-formatter)
@@ -82,4 +82,8 @@ After compiling the product-formatter raw\_binary libraries and tools, the conve
 ### Product Guide
 
 ## Release Notes
-1. Fill value for the angle bands is -32768 instead of -9999.
+1. Fixed broken links in the LAADS auxiliary Makefile.
+2. Fixed a compiler warning in the combine LAADS C code.
+3. Modified the LAADS update scripts to use the MODIS public http server -
+   https://ladsweb.modaps.eosdis.nasa.gov instead of the ftp server
+   ftp://ladssci.nascom.nasa.gov.

--- a/lasrc/README.md
+++ b/lasrc/README.md
@@ -65,9 +65,7 @@ See git tag [lasrc-version_1.1.0]
 ### Auxiliary Data Updates
 The baseline auxiliary files provided don't include the daily climate data.  In order to generate or update the auxiliary files to the most recent day of year (actually the most current auxiliary files available will be 2-3 days prior to the current day of year do to the latency of the underlying LAADS products) the user will want to run the updatelads.py script available in $PREFIX/bin.  This script can be run with the "--help" argument to print the usage information.  In general the --quarterly argument will reprocess/update all the LAADS data back to 2013.  This is good to do every once in a while to make sure any updates to the LAADS data products are captured.  The --today command-line argument will process the LAADS data for the most recent year.  In general, it is suggested to run the script with --quarterly once a quarter.  Then run the script with --today on a nightly basis.  This should provide an up-to-date version of the auxiliary input data for LaSRC.  The easiest way to accomplish this is to set up a nightly and quarterly cron job.
 
-The updatelads script requires a username/password to access the ladssci.nascom.nasa.gov FTP site.  The user will need to contact USGS EROS Customer Services to obtain a username/password for the LAADS FTP site.  In your email explain that you will be using this ftp access to obtain LAADS data for processing Landsat 8 products using the LaSRC application provided by the USGS EROS.  For questions regarding this information, please contact the Landsat Contact Us page and specify USGS CDR/ECV in the "Regarding" section. https://landsat.usgs.gov/contactus.php
-
-The provided username and password should be used in the --username and --password command-line arguments for the updatelads.py script.  If not specified the source code will try to use the ESPA_LAADS_CONFIG http service to automatically determine the username/password, which is only available to the USGS LSRD systems.
+The updatelads script now accesses a public http site instead of the previous LAADS FTP site which required a username/password.  Therefore the update LAADS script should be usable by all users, as-is, and should not require additional modifications or a special username and password.
 
 ### Data Preprocessing
 This version of the LaSRC application requires the input Landsat products to be in the ESPA internal file format.  After compiling the product formatter raw\_binary libraries and tools, the convert\_lpgs\_to\_espa command-line tool can be used to create the ESPA internal file format for input to the LaSRC application.
@@ -87,4 +85,6 @@ After compiling the product-formatter raw\_binary libraries and tools, the conve
 3. Modified the LAADS update scripts to use the MODIS public http server -
    https://ladsweb.modaps.eosdis.nasa.gov instead of the ftp server
    ftp://ladssci.nascom.nasa.gov.
+   This LAADS data has been moved to the public http site and allows all users
+   of the update LAADS scripts to access the data without a username/password.
 4. Updated the application version number.

--- a/lasrc/c_version/src/common.h
+++ b/lasrc/c_version/src/common.h
@@ -13,7 +13,7 @@ typedef char byte;
 #endif
 
 /* Surface reflectance version */
-#define SR_VERSION "1.0.1"
+#define SR_VERSION "1.1.0"
 
 /* How many lines of data should be processed at one time */
 #define PROC_NLINES 1000

--- a/lasrc/c_version/src_pre_collection/common.h
+++ b/lasrc/c_version/src_pre_collection/common.h
@@ -13,7 +13,7 @@ typedef char byte;
 #endif
 
 /* Surface reflectance version */
-#define SR_VERSION "1.0.1"
+#define SR_VERSION "1.1.0"
 
 /* How many lines of data should be processed at one time */
 #define PROC_NLINES 1000

--- a/lasrc/landsat_aux/scripts/Makefile
+++ b/lasrc/landsat_aux/scripts/Makefile
@@ -17,11 +17,11 @@ all:
 
 install:
 	install -d $(link_path)
-	install -d $(l8_bin_install_path)
+	install -d $(lasrc_bin_install_path)
 	@for script in $(SCRIPTS); do \
-            cmd="install -m 755 $$script $(l8_bin_install_path)"; \
+            cmd="install -m 755 $$script $(lasrc_bin_install_path)"; \
             echo "$$cmd"; $$cmd; \
-            cmd="ln -sf $(l8_link_source_path)/$$script $(link_path)/$$script"; \
+            cmd="ln -sf $(lasrc_link_source_path)/$$script $(link_path)/$$script"; \
             echo "$$cmd"; $$cmd; \
         done;
 

--- a/lasrc/landsat_aux/scripts/updatelads.py
+++ b/lasrc/landsat_aux/scripts/updatelads.py
@@ -8,7 +8,6 @@
 import sys
 import os
 import fnmatch
-import ftplib
 import datetime
 import commands
 import re
@@ -33,26 +32,15 @@ class DatasourceResolver:
     # correct subdirectories for each of the instrument-specific ozone
     # products
     # These are version 006 products
-    SERVER_URL = 'ladssci.nascom.nasa.gov'
-    TERRA_CMA = '/allData/6/MOD09CMA/'
-    TERRA_CMG = '/allData/6/MOD09CMG/'
-    AQUA_CMA = '/allData/6/MYD09CMA/'
-    AQUA_CMG = '/allData/6/MYD09CMG/'
-
-    user = None
-    password = None
-
-    def __init__(self):
-        if(self.user is None or self.password is None):
-            (self.user, self.password) = get_credentials_from_production()
-
-        logger = logging.getLogger(__name__)  # Obtain logger for this module.
-        logger.info('LADSFTP username: {0}'.format(self.user))
-        logger.info('LADSFTP password: {0}'.format(self.password))
+    SERVER_URL = 'ladsweb.modaps.eosdis.nasa.gov'
+    TERRA_CMA = '/archive/allData/6/MOD09CMA/'
+    TERRA_CMG = '/archive/allData/6/MOD09CMG/'
+    AQUA_CMA = '/archive/allData/6/MYD09CMA/'
+    AQUA_CMG = '/archive/allData/6/MYD09CMG/'
 
 
     #######################################################################
-    # Description: buildURL builds the URLs for the Terra and Aqua CMG and
+    # Description: buildURLs builds the URLs for the Terra and Aqua CMG and
     # CMA products for the current year and DOY, and put that URL on the list.
     #
     # Inputs:
@@ -70,28 +58,24 @@ class DatasourceResolver:
     def buildURLs(self, year, doy):
         urlList = []     # create empty URL list
 
-        # append TERRA CMA data
-        url = 'ftp://%s:%s@%s%s%d/%03d/MOD09CMA*%d%03d*.hdf' % \
-            (self.user, self.password, self.SERVER_URL, self.TERRA_CMA, year,
-             doy, year, doy)
+        # append TERRA CMA data (MOD09CMA)
+        url = ('https://{}{}{}/{:03d}/'
+               .format(self.SERVER_URL, self.TERRA_CMA, year, doy))
         urlList.append(url)
 
-        # append TERRA CMG data
-        url = 'ftp://%s:%s@%s%s%d/%03d/MOD09CMG*%d%03d*.hdf' % \
-            (self.user, self.password, self.SERVER_URL, self.TERRA_CMG, year,
-             doy, year, doy)
+        # append TERRA CMG data (MOD09CMG)
+        url = ('https://{}{}{}/{:03d}/'
+               .format(self.SERVER_URL, self.TERRA_CMG, year, doy))
         urlList.append(url)
 
-        # append AQUA CMA data
-        url = 'ftp://%s:%s@%s%s%d/%03d/MYD09CMA*%d%03d*.hdf' % \
-            (self.user, self.password, self.SERVER_URL, self.AQUA_CMA, year,
-             doy, year, doy)
+        # append AQUA CMA data (MYD09CMA)
+        url = ('https://{}{}{}/{:03d}/'
+               .format(self.SERVER_URL, self.AQUA_CMA, year, doy))
         urlList.append(url)
 
-        # append AQUA CMG data
-        url = 'ftp://%s:%s@%s%s%d/%03d/MYD09CMG*%d%03d*.hdf' % \
-            (self.user, self.password, self.SERVER_URL, self.AQUA_CMG, year,
-             doy, year, doy)
+        # append AQUA CMG data (MYD09CMG)
+        url = ('https://{}{}{}/{:03d}/'
+               .format(self.SERVER_URL, self.AQUA_CMG, year, doy))
         urlList.append(url)
 
         return urlList
@@ -99,66 +83,6 @@ class DatasourceResolver:
 ############################################################################
 # End DatasourceResolver class
 ############################################################################
-
-
-#######################################################################
-# Description: Obtains ftp credentials (username and password) from
-# production service.
-#
-# Precondition:
-#   Requires environmental variable, ESPA_LAADS_CONFIG, to be set equal to the
-#       http address of the service.
-#   Assumes ESPA_LAADS_CONFIG http link is accessable from local system.
-#
-# Postcondition:
-#   Returns tuple containing (username, password)
-#   Returns None if error occured
-#       Occurs if service could not be reached
-#       Occurs if empty credentials were recieved from the service
-#
-#######################################################################
-def get_credentials_from_production():
-    # get the logger
-    logger = logging.getLogger(__name__)
-
-    # determine the auxiliary directory to store the data
-    laads_config = os.environ.get('ESPA_LAADS_CONFIG')
-    if laads_config is None:
-        msg = "ESPA_LAADS_CONFIG environment variable not set... exiting"
-        logger.error(msg)
-        return None
-
-    # get the LAADS username and password
-    # username
-    username_url = '{0}/ladsftp.username'.format(laads_config)
-    response = requests.get(username_url)
-    if not response.ok:
-        msg = 'Error fetching LAADS credentials'
-        logger.error(msg)
-        return None
-    user = response.json()['ladsftp.username']
-    logger.debug('username: {0}'.format(user))
-
-    # password
-    pwd_url = '{0}/ladsftp.password'.format(laads_config)
-    response = requests.get(pwd_url)
-    if not response.ok:
-        msg = 'Error fetching LAADS credentials'
-        logger.error(msg)
-        return None
-    password = response.json()['ladsftp.password']
-    logger.debug('password: {0}'.format(password))
-
-    # verify that the ESPA_LAADS_CONFIG service returned valid information and
-    # the username and password were set in the configuration
-    if len(user) <= 0 or len(password) <= 0:
-        msg = "Received invalid sized credentials for LAADS FTP from " \
-            "ESPA_LAADS_CONFIG service. Make sure ladsftp.username and " \
-            "ladsftp.password are set in the ESPA_LAADS_CONFIG."
-        logger.error(msg)
-        return None
-
-    return (user, password)
 
 
 ############################################################################
@@ -189,7 +113,7 @@ def isLeapYear (year):
 
 ############################################################################
 # Description: downloadLads will retrieve the files for the specified year
-# and DOY from the LAADS ftp site and download to the desired destination.
+# and DOY from the LAADS http site and download to the desired destination.
 # If the destination directory does not exist, then it is made before
 # downloading.  Existing files in the download directory are removed/cleaned.
 # This will download the Aqua/Terra CMG and CMA files for the current year, DOY.
@@ -205,8 +129,6 @@ def isLeapYear (year):
 #     SUCCESS - processing completed successfully
 #
 # Notes:
-#   We could use the Python ftplib or urllib modules, however the wget
-#   function is pretty short and sweet, so we'll stick with wget.
 ############################################################################
 def downloadLads (year, doy, destination):
     # get the logger
@@ -215,13 +137,13 @@ def downloadLads (year, doy, destination):
     # make sure the download directory exists (and is cleaned up) or create
     # it recursively
     if not os.path.exists(destination):
-        msg = "%s does not exist... creating" % destination
+        msg = '{} does not exist... creating'.format(destination)
         logger.info(msg)
         os.makedirs(destination, 0777)
     else:
         # directory already exists and possibly has files in it.  any old
         # files need to be cleaned up
-        msg = "Cleaning download directory: %s" % destination
+        msg = 'Cleaning download directory: {}'.format(destination)
         logger.info(msg)
         for myfile in os.listdir(destination):
             name = os.path.join(destination, myfile)
@@ -232,8 +154,8 @@ def downloadLads (year, doy, destination):
     # locations for the Aqua and Terra CMG/CMA files.
     urlList = DatasourceResolver().buildURLs(year, doy)
     if urlList is None:
-        msg = "LAADS URLs could not be resolved for year %d and DOY %d." % \
-            (year, doy)
+        msg = ('LAADS URLs could not be resolved for year {} and DOY {}'
+               .format(year, doy))
         logger.error(msg)
         return ERROR
 
@@ -241,12 +163,13 @@ def downloadLads (year, doy, destination):
     # if there is a problem with the connection, then retry up to 5 times.
     # Note: if you don't like the wget output, --quiet can be used to minimize
     # the output info.
-    msg = "Downloading data for year %d to: %s" % (year, destination)
+    msg = 'Downloading data for year {} to {}'.format(year, destination)
     logger.info(msg)
     for url in urlList:
-        msg = "Retrieving %s to %s" % (url, destination)
+        msg = 'Retrieving {} to {}'.format(url, destination)
         logger.info(msg)
-        cmd = 'wget --tries=5 %s' % url
+        cmd = ('wget --tries=5 --directory-prefix=. --no-directories '
+               '--recursive --level=1 --no-parent --accept hdf {}'.format(url))
         retval = subprocess.call(cmd, shell=True, cwd=destination)
 
         # make sure the wget was successful or retry up to 5 more times and
@@ -255,13 +178,13 @@ def downloadLads (year, doy, destination):
             retry_count = 1
             while ((retry_count <= 5) and (retval)):
                 time.sleep(60)
-                logger.info('Retry {0} of wget for {1}'
+                logger.info('Retry {} of wget for {}'
                             .format(retry_count, url))
                 retval = subprocess.call(cmd, shell=True, cwd=destination)
                 retry_count += 1
 
             if retval:
-                logger.warn('Unsuccessful download of {0} (retried 5 times)'
+                logger.warn('Unsuccessful download of {} (retried 5 times)'
                             .format(url))
 
     return SUCCESS
@@ -291,9 +214,9 @@ def getLadsData (auxdir, year, today):
 
     # determine the directory for the output auxiliary data files to be
     # processed.  create the directory if it doesn't exist.
-    outputDir = "%s/LADS/%d" % (auxdir, year)
+    outputDir = '{}/LADS/{}'.format(auxdir, year)
     if not os.path.exists(outputDir):
-        msg = "%s does not exist... creating" % outputDir
+        msg = '{} does not exist... creating'.format(outputDir)
         logger.info(msg)
         os.makedirs(outputDir, 0777)
 
@@ -314,14 +237,14 @@ def getLadsData (auxdir, year, today):
             day_of_year = 365
 
     # set the download directory in /tmp/lads
-    dloaddir = "/tmp/lads/%d" % year
+    dloaddir = '/tmp/lads/{}'.format(year)
 
     # loop through each day in the year and process the LAADS data.  process
     # in the reverse order so that if we are handling data for "today", then
     # we can stop as soon as we find the current DOY has been processed.
     for doy in range(day_of_year, 0, -1):
         # get the year + DOY string
-        datestr = "%d%03d" % (year, doy)
+        datestr = '{}{:03d}'.format(year, doy)
 
         # if the data for the current year and doy exists already, then we are
         # going to skip that file if processing for the --today.  For
@@ -330,7 +253,7 @@ def getLadsData (auxdir, year, today):
         for myfile in os.listdir(outputDir):
             if fnmatch.fnmatch (myfile, 'L8ANC' + datestr + '.hdf_fused') \
                 and today:
-                msg = 'L8ANC' + datestr + '.hdf_fused already exists. Skip.'
+                msg = 'L8ANC{}.hdf_fused already exists. Skip.'.format(datestr)
                 logger.info(msg)
                 skip_date = True
                 break
@@ -353,8 +276,8 @@ def getLadsData (auxdir, year, today):
         # make sure files were found or print a warning
         nfiles = len(fileList)
         if nfiles == 0:
-            msg = "No LAADS MOD09CMA data available for doy %d year %d." % \
-                (doy, year)
+            msg = ('No LAADS MOD09CMA data available for doy {} year {}.'
+                   .format(doy, year))
             logger.warning(msg)
             continue
         else:
@@ -364,8 +287,8 @@ def getLadsData (auxdir, year, today):
             if nfiles == 1:
                 terra_cma = dloaddir + '/' + fileList[0]
             else:
-                msg = "Multiple LAADS MOD09CMA files found for doy %d year " \
-                    "%d." % (doy, year)
+                msg = ('Multiple LAADS MOD09CMA files found for doy {} year {}'
+                       .format(doy, year))
                 logger.error(msg)
                 return ERROR
 
@@ -378,8 +301,8 @@ def getLadsData (auxdir, year, today):
         # make sure files were found or print a warning
         nfiles = len(fileList)
         if nfiles == 0:
-            msg = "No LAADS MOD09CMG data available for doy %d year %d." % \
-                (doy, year)
+            msg = ('No LAADS MOD09CMG data available for doy {} year {}.'
+                   .format(doy, year))
             logger.warning(msg)
             continue
         else:
@@ -389,8 +312,8 @@ def getLadsData (auxdir, year, today):
             if nfiles == 1:
                 terra_cmg = dloaddir + '/' + fileList[0]
             else:
-                msg = "Multiple LAADS MOD09CMG files found for doy %d year " \
-                    "%d." % (doy, year)
+                msg = ('Multiple LAADS MOD09CMG files found for doy {} year {}'
+                       .format(doy, year))
                 logger.error(msg)
                 return ERROR
 
@@ -403,8 +326,8 @@ def getLadsData (auxdir, year, today):
         # make sure files were found or print a warning
         nfiles = len(fileList)
         if nfiles == 0:
-            msg = "No LAADS MYD09CMA data available for doy %d year %d." % \
-                (doy, year)
+            msg = ('No LAADS MYD09CMA data available for doy {} year {}.'
+                   .format(doy, year))
             logger.warning(msg)
             continue
         else:
@@ -414,8 +337,8 @@ def getLadsData (auxdir, year, today):
             if nfiles == 1:
                 aqua_cma = dloaddir + '/' + fileList[0]
             else:
-                msg = "Multiple LAADS MYD09CMA files found for doy %d year " \
-                    "%d." % (doy, year)
+                msg = ('Multiple LAADS MOD09CMA files found for doy {} year {}'
+                       .format(doy, year))
                 logger.error(msg)
                 return ERROR
 
@@ -428,8 +351,8 @@ def getLadsData (auxdir, year, today):
         # make sure files were found or print a warning
         nfiles = len(fileList)
         if nfiles == 0:
-            msg = "No LAADS MYD09CMG data available for doy %d year %d." % \
-                (doy, year)
+            msg = ('No LAADS MYD09CMG data available for doy {} year {}.'
+                   .format(doy, year))
             logger.warning(msg)
             continue
         else:
@@ -439,31 +362,31 @@ def getLadsData (auxdir, year, today):
             if nfiles == 1:
                 aqua_cmg = dloaddir + '/' + fileList[0]
             else:
-                msg = "Multiple LAADS MYD09CMG files found for doy %d year " \
-                    "%d." % (doy, year)
+                msg = ('Multiple LAADS MYD09CMA files found for doy {} year {}'
+                       .format(doy, year))
                 logger.error(msg)
                 return ERROR
 
         # generate the full path for the input and output file to be
         # processed. if the output file already exists, then remove it.
-        cmdstr = 'combine_l8_aux_data --terra_cmg %s --terra_cma %s ' \
-            '--aqua_cmg %s --aqua_cma %s --output_dir %s' % (terra_cmg, \
-            terra_cma, aqua_cmg, aqua_cma, outputDir)
-        msg = "Executing %s\n" % cmdstr
+        cmdstr = ('combine_l8_aux_data --terra_cmg {} --terra_cma {} '
+                  '--aqua_cmg {} --aqua_cma {} --output_dir {}'
+                  .format(terra_cmg, terra_cma, aqua_cmg, aqua_cma, outputDir))
+        msg = 'Executing {}'.format(cmdstr)
         logger.info(msg)
 
         (status, output) = commands.getstatusoutput (cmdstr)
         logger.info(output)
         exit_code = status >> 8
         if exit_code != 0:
-            msg = "Error running combine_l8_aux_data for year %d, DOY %d." % \
-                (year, doy)
+            msg = ('Error running combine_l8_aux_data for year {}, DOY {}'
+                   .format(year, doy))
             logger.error(msg)
             return ERROR
     # end for doy
 
     # remove the files downloaded to the temporary directory
-    msg = "Removing downloaded files from %s" % dloaddir
+    msg = 'Removing downloaded files from {}'.format(dloaddir)
     logger.info(msg)
     if os.path.exists(dloaddir):
         for myfile in os.listdir(dloaddir):
@@ -509,17 +432,11 @@ def main ():
         default=0, help='year for which to start pulling LAADS data')
     parser.add_option ('-e', '--end_year', type='int', dest='eyear',
         default=0, help='last year for which to pull LAADS data')
-    parser.add_option('-u', '--username', dest='username', type='string',
-                      help='username to use for LAADS ftp site '
-                           '(ladssci.nascom.nasa.gov)')
-    parser.add_option('-p', '--password', dest='password', type='string',
-                      help='password to use for LAADS ftp site '
-                           '(ladssci.nascom.nasa.gov)')
     parser.add_option ('--today', dest='today', default=False,
         action='store_true',
         help='process LAADS data up through the most recent year and DOY')
-    msg = 'process or reprocess all LAADS data from today back to %d' %  \
-        START_YEAR
+    msg = ('process or reprocess all LAADS data from today back to {}'
+           .format(START_YEAR))
     parser.add_option ('--quarterly', dest='quarterly', default=False,
         action='store_true', help=msg)
 
@@ -529,28 +446,18 @@ def main ():
     today = options.today           # process most recent year of data
     quarterly = options.quarterly   # process today back to START_YEAR
 
-    if((options.username is None) and (options.password is None)):
-        logger.info('Credentials obtained from ESPA_LAADS_CONFIG service will '
-                    'be used')
-    elif((options.username is not None) and (options.password is not None)):
-        DatasourceResolver.user = options.username
-        DatasourceResolver.password = options.password
-    else:
-        raise Exception('It is invalid to specify --username or --password'
-                        ' argument without the other.')
-
     # check the arguments
     if (today == False) and (quarterly == False) and \
        (syear == 0 or eyear == 0):
-        msg = "Invalid command line argument combination.  Type --help "  \
-            "for more information"
+        msg = ('Invalid command line argument combination.  Type --help '
+              'for more information.')
         logger.error(msg)
         return ERROR
 
     # determine the auxiliary directory to store the data
     auxdir = os.environ.get('L8_AUX_DIR')
     if auxdir is None:
-        msg = "L8_AUX_DIR environment variable not set... exiting"
+        msg = 'L8_AUX_DIR environment variable not set... exiting'
         logger.error(msg)
         return ERROR
 
@@ -558,7 +465,7 @@ def main ():
     # DOY is within the first month, then process the previous year as well
     # to make sure we have all the recently available data processed.
     if today:
-        msg = "Processing LAADS data up to the most recent year and DOY."
+        msg = 'Processing LAADS data up to the most recent year and DOY.'
         logger.info(msg)
         now = datetime.datetime.now()
         day_of_year = now.timetuple().tm_yday
@@ -569,20 +476,20 @@ def main ():
             syear = eyear
 
     elif quarterly:
-        msg = "Processing LAADS data back to %d" % START_YEAR
+        msg = 'Processing LAADS data back to {}'.format(START_YEAR)
         logger.info(msg)
         eyear = now.year
         syear = START_YEAR
 
-    msg = 'Processing LAADS data for %d - %d' % (syear, eyear)
+    msg = 'Processing LAADS data for {} - {}'.format(syear, eyear)
     logger.info(msg)
     for yr in range(eyear, syear-1, -1):
-        msg = 'Processing year: %d' % yr
+        msg = 'Processing year: {}'.format(yr)
         logger.info(msg)
         status = getLadsData(auxdir, yr, today)
         if status == ERROR:
-            msg = "Problems occurred while processing LAADS data for year " \
-                "%d." % yr
+            msg = ('Problems occurred while processing LAADS data for year {}'
+                   .format(yr))
             logger.error(msg)
             return ERROR
 

--- a/lasrc/landsat_aux/src/Makefile
+++ b/lasrc/landsat_aux/src/Makefile
@@ -50,9 +50,9 @@ $(EXE): $(OBJ) $(INC)
 #-----------------------------------------------------------------------------
 install:
 	install -d $(link_path)
-	install -d $(l8_bin_install_path)
-	install -m 755 $(EXE) $(l8_bin_install_path)
-	ln -sf $(l8_link_source_path)/$(EXE) $(link_path)/$(EXE)
+	install -d $(lasrc_bin_install_path)
+	install -m 755 $(EXE) $(lasrc_bin_install_path)
+	ln -sf $(lasrc_link_source_path)/$(EXE) $(link_path)/$(EXE)
 
 #-----------------------------------------------------------------------------
 clean:

--- a/lasrc/landsat_aux/src/combine_l8_aux_data.c
+++ b/lasrc/landsat_aux/src/combine_l8_aux_data.c
@@ -1012,7 +1012,7 @@ int metareader
     int data_type;          /* data type of the attribute */
     int nvals;              /* number of values in the attribute */
     int n_obj;              /* number of OBJECT strings we've counted */
-    int n_val;              /* number of values for the current attribute */
+    int n_val=0;            /* number of values for the current attribute */
     int start;              /* location of the character string to start
                                reading lines */
     int obj_offset[10];     /* offset of location of OBJECT token */


### PR DESCRIPTION
This is the hot release for the LAADS update scripts to switch from the current ftp server which requires a username/password to the public http site.  The code which pulled the LAADS credentials is no longer needed, and the support for a username/password to be passed into the application has been removed as well.  The wget call to pull data from the http site is slightly different from the wget for the ftp site, mainly because glob is not supported with the http access.
I also fixed a couple of broken links in the Makefiles for the LAADS update scripts and C code.  And, I switched the string handling to use .format.