### PR TITLE
get LAADS token from environment variable

### DIFF
--- a/lasrc/landsat_aux/scripts/updatelads.py
+++ b/lasrc/landsat_aux/scripts/updatelads.py
@@ -31,7 +31,7 @@ START_YEAR = 2013      # quarterly processing will reprocess back to the
 ##NOTE: For non-ESPA environments, the TOKEN needs to be defined.  This is
 ##the application token that is required for accessing the LAADS data
 ##https://ladsweb.modaps.eosdis.nasa.gov/tools-and-services/data-download-scripts/
-TOKEN = None
+TOKEN = os.environ.get('LAADS_TOKEN', None)
 USERAGENT = 'espa.cr.usgs.gov/updatelads.py 1.4.1--' + sys.version.replace('\n','').replace('\r','')
 
 # Specify the base location for the LAADS data as well as the


### PR DESCRIPTION
A tiny proposed addition to the `updatelads.py` script: In addition to hard-coding the LAADS token into the script file or configuring an API via `processing.conf`, the user could specify it as an environment variable `LAADS_TOKEN`. 