### PR TITLE
Implemented the combined band 6 computation for brightness temp

### DIFF
--- a/ledaps/README.md
+++ b/ledaps/README.md
@@ -1,5 +1,5 @@
-## Ledaps Version 3.3.1 Release Notes
-Release Date: March 2019
+## Ledaps Version 3.4.0 Release Notes
+Release Date: July 2019
 
 ### Downloads
 Ledaps source code
@@ -10,7 +10,7 @@ Ledaps auxiliary files
 
     http://edclpdsftp.cr.usgs.gov/downloads/auxiliaries/ledaps_auxiliary/ledaps_aux.1978-2017.tar.gz
 
-See git tag [ledaps-version_3.3.1]
+See git tag [ledaps-version_3.4.0]
 
 ### Installation
   * Install dependent projects and libraries - ESPA product formatter (https://github.com/USGS-EROS/espa-product-formatter) and ESPA python library (https://github.com/USGS-EROS/espa-python-library)
@@ -92,10 +92,13 @@ After compiling the product-formatter raw\_binary libraries and tools, the conve
 ### Product Guide
 
 ## Release Notes
-  1. Fixed a bug introduced to the cloud shadow code when multi-threading was
-     added.  This bug only affects the cloud shadow computation when the band
-     6 clear temperature values are invalid, in which case the ancillary
-     airtemp_2m values are used from the cloud diagnostics.  The interpolation
-     of these ancillary values is where the bug resides and a value of -9999
-     is ultimately used, and therefore the cloud shadow is not computed for
-     the pixel.
+  1. The ETM+ band 6 BT band output from lndcal will be a combined product of
+     band 6H and band 6L. The basis for ETM+ BT will be band 6H (instead of
+     band 6L). If band 6H is saturated, then band 6L will be used to compute
+     the BT value. If both bands are saturated, then the saturation value is
+     written and the RADSAT band is masked as saturated for this pixel.
+     Band 6H saturation is a value equal to 255 (high) or a value equal to 1
+     (low).  Band 6L saturation is a value equal to 255.  Low saturation does
+     not occur in Band 6L.
+  2. Also removed the calibration statistics calculation, since that is not
+     turned on for implementation.

--- a/ledaps/ledapsSrc/src/lndcal/cal.c
+++ b/ledaps/ledapsSrc/src/lndcal/cal.c
@@ -17,7 +17,7 @@
 
 bool Cal(Param_t *param, Lut_t *lut, int iband, Input_t *input,
          unsigned char *line_in, int16 *line_in_sun_zen, int16 *line_out,
-         unsigned char *line_out_qa, Cal_stats_t *cal_stats, int iy) {
+         unsigned char *line_out_qa, int iy) {
   int is,val;
   float rad_gain, rad_bias;           /* TOA radiance gain/bias */
   float refl_gain = 0.0,
@@ -43,8 +43,8 @@ bool Cal(Param_t *param, Lut_t *lut, int iband, Input_t *input,
 
     if ( iy==0 ) {
       printf("*** band=%1d refl gain=%f refl bias=%f "
-            "cos_sun_zen(scene center)=%f\n", iband+1, refl_gain, refl_bias,
-            lut->cos_sun_zen);
+            "cos_sun_zen(scene center)=%f\n", lut->meta.iband[iband],
+            refl_gain, refl_bias, lut->cos_sun_zen);
       fflush(stdout);
     }
   }
@@ -53,7 +53,7 @@ bool Cal(Param_t *param, Lut_t *lut, int iband, Input_t *input,
   
     if ( iy==0 ) {
       printf("*** band=%1d rad gain=%f rad bias=%f dsun2=%f\n"
-             "    ref_conv=%f=(PI*%f)/(%f*%f) ***\n", iband+1,
+             "    ref_conv=%f=(PI*%f)/(%f*%f) ***\n", lut->meta.iband[iband],
              rad_gain, rad_bias, lut->dsun2, ref_conv, lut->dsun2,
              lut->esun[iband], lut->cos_sun_zen);
       fflush(stdout);
@@ -105,61 +105,33 @@ bool Cal(Param_t *param, Lut_t *lut, int iband, Input_t *input,
       line_out[is] = lut->valid_range_ref[1];
       ref = line_out[is] * 0.0001;
     }
-
-#ifdef DO_STATS
-    if (cal_stats->first[iband]) {
-      cal_stats->idn_min[iband] = val;
-      cal_stats->idn_max[iband] = val;
-
-      cal_stats->rad_min[iband] = rad;
-      cal_stats->rad_max[iband] = rad;
-
-      cal_stats->ref_min[iband] = ref;
-      cal_stats->ref_max[iband] = ref;
-
-      cal_stats->iref_min[iband] = line_out[is];
-      cal_stats->iref_max[iband] = line_out[is];
-
-      cal_stats->first[iband] = false;
-    } else {
-      if (val < cal_stats->idn_min[iband]) 
-        cal_stats->idn_min[iband] = val;
-      if (val > cal_stats->idn_max[iband]) 
-        cal_stats->idn_max[iband] = val;
-
-      if (rad < cal_stats->rad_min[iband]) cal_stats->rad_min[iband] = rad;
-      if (rad > cal_stats->rad_max[iband]) cal_stats->rad_max[iband] = rad;
-
-      if (ref < cal_stats->ref_min[iband]) cal_stats->ref_min[iband] = ref;
-      if (ref > cal_stats->ref_max[iband]) cal_stats->ref_max[iband] = ref;
-
-      if (line_out[is] < cal_stats->iref_min[iband]) 
-        cal_stats->iref_min[iband] = line_out[is];
-      if (line_out[is] > cal_stats->iref_max[iband]) 
-        cal_stats->iref_max[iband] = line_out[is];
-    }
-#endif
   }  /* end for is */
 
   return true;
 }
 
+/* Brightness Temp Calibration for TM.  Band 6 is the only band available for
+   computing brightness temp. */
 bool Cal6(Lut_t *lut, Input_t *input, unsigned char *line_in, int16 *line_out,
-          unsigned char *line_out_qa, Cal_stats6_t *cal_stats, int iy) {
+          unsigned char *line_out_qa, int iy) {
   int is, val;
   float rad_gain, rad_bias, rad, temp;
   int nsamp= input->size_th.s;
   int ifill= (int)lut->in_fill;
 
-  rad_gain = lut->meta.rad_gain_th;
-  rad_bias = lut->meta.rad_bias_th;
+  /* The gain and bias are only for band 6 in this case */
+  rad_gain = lut->meta.rad_gain_th[0];
+  rad_bias = lut->meta.rad_bias_th[0];
   
   if ( iy==0 ) {
     printf("*** band=%1d gain=%f bias=%f ***\n", 6, rad_gain, rad_bias);
   }
 
+  /* Loop through the pixels in this line */
   for (is = 0; is < nsamp; is++) {
     val = line_in[is];
+
+    /* for fill pixels */
     if (val == ifill || line_out_qa[is]==lut->qa_fill ) {
       line_out[is] = lut->out_fill;
       continue;
@@ -175,54 +147,97 @@ bool Cal6(Lut_t *lut, Input_t *input, unsigned char *line_in, int16 *line_out,
        10.0 (tied to lut->scale_factor_th). valid ranges are set up in lut.c
        as well. */
     rad = (rad_gain * (float)val) + rad_bias;
-    temp = lut->K2 / log(1.0 + (lut->K1/rad));
+    temp = lut->K2[0] / log(1.0 + (lut->K1[0]/rad));
     line_out[is] = (int16)(temp * 10.0 + 0.5);
 
-    /* Cap the output using the min/max values.  Then reset the temperature
-       value so that it's correctly reported in the stats and the min/max
-       range matches that of the image data. */
-    if (line_out[is] < lut->valid_range_th[0]) {
+    /* Cap the output using the min/max values */
+    if (line_out[is] < lut->valid_range_th[0])
       line_out[is] = lut->valid_range_th[0];
-      temp = line_out[is] * 0.1;
-    }
-    else if (line_out[is] > lut->valid_range_th[1]) {
+    else if (line_out[is] > lut->valid_range_th[1])
       line_out[is] = lut->valid_range_th[1];
-      temp = line_out[is] * 0.1;
+  }  /* end for is */
+
+  return true;
+}
+
+/* Brightness Temp Calibration for ETM+.  Band 6H is the primary band used for
+   brightness temp.  If Band 6H is saturated, then Band 6L is used.  If it is
+   also saturated then the pixel is masked as saturated. */
+#define BAND_6L 0
+#define BAND_6H 1
+bool Cal6_combined(Lut_t *lut, Input_t *input, unsigned char *line_b6l,
+  unsigned char *line_b6h, int16 *line_out, unsigned char *line_out_qa,
+  int iy) {
+  int is;               /* looping variable for pixels */
+  int cband;            /* index for 6L or 6H to be used in the combined band */
+  int val[2];           /* input thermal value for band 6L, 6H */
+  int nsamp = input->size_th.s;
+  int ifill = (int)lut->in_fill;
+  float rad_gain[2], rad_bias[2], rad, temp;
+  float k1[2], k2[2];   /* thermal consts from the LUT */
+
+  /* Set up the calibration coefficients */
+  rad_gain[BAND_6L] = lut->meta.rad_gain_th[BAND_6L];
+  rad_bias[BAND_6L] = lut->meta.rad_bias_th[BAND_6L];
+  rad_gain[BAND_6H] = lut->meta.rad_gain_th[BAND_6H];
+  rad_bias[BAND_6H] = lut->meta.rad_bias_th[BAND_6H];
+  k1[BAND_6L] = lut->K1[BAND_6L];
+  k2[BAND_6L] = lut->K2[BAND_6L];
+  k1[BAND_6H] = lut->K1[BAND_6H];
+  k2[BAND_6H] = lut->K2[BAND_6H];
+  
+  if ( iy==0 ) {
+    printf("*** band=6L gain=%f bias=%f ***\n", rad_gain[BAND_6L],
+      rad_bias[BAND_6L]);
+    printf("*** band=6H gain=%f bias=%f ***\n", rad_gain[BAND_6H],
+      rad_bias[BAND_6H]);
+  }
+
+  /* Loop through the pixels in this line */
+  for (is = 0; is < nsamp; is++) {
+    val[BAND_6L] = line_b6l[is];
+    val[BAND_6H] = line_b6h[is];
+
+    /* For saturated pixels. If one band is fill they are both fill. */
+    if (val[BAND_6H] == ifill || line_out_qa[is]==lut->qa_fill ) {
+      line_out[is] = lut->out_fill;
+      continue;
     }
 
-#ifdef DO_STATS
-    if (cal_stats->first) {
-      cal_stats->idn_min = val;
-      cal_stats->idn_max = val;
-
-      cal_stats->rad_min = rad;
-      cal_stats->rad_max = rad;
-
-      cal_stats->temp_min = temp;
-      cal_stats->temp_max = temp;
-
-      cal_stats->itemp_min = line_out[is];
-      cal_stats->itemp_max = line_out[is];
-
-      cal_stats->first = false;
-    } else {
-      if (val < (int)cal_stats->idn_min) 
-        cal_stats->idn_min = val;
-      if (val > cal_stats->idn_max) 
-        cal_stats->idn_max = val;
-
-      if (rad < cal_stats->rad_min) cal_stats->rad_min = rad;
-      if (rad > cal_stats->rad_max) cal_stats->rad_max = rad;
-
-      if (temp < cal_stats->temp_min) cal_stats->temp_min = temp;
-      if (temp > cal_stats->temp_max) cal_stats->temp_max = temp;
-
-      if (line_out[is] < cal_stats->itemp_min) 
-        cal_stats->itemp_min = line_out[is];
-      if (line_out[is] > cal_stats->itemp_max) 
-        cal_stats->itemp_max = line_out[is];
+    /* If band 6H is not saturated, it will be used for the brightness temp.
+       Otherwise if band 6L is not saturated, it will be used for the
+       brightness temp. If both are saturated, then the output is saturated. */
+    if ((val[BAND_6H] < SATU_VAL6) && (val[BAND_6H] > SATU_LOW_VAL6)) {
+      /* use band 6H for the combined band */
+      cband = BAND_6H;
     }
-#endif
+    else {
+      if ((val[BAND_6L] < SATU_VAL6) && (val[BAND_6L] > SATU_LOW_VAL6)) {
+        /* use band 6L for the combined band */
+        cband = BAND_6L;
+      }
+      else {
+        /* both bands are saturated. flag it as saturated (just in case we
+           missed something by using the band 6L high saturation check).
+           move on to the next pixel. */
+        line_out[is] = lut->out_satu;
+        line_out_qa[is] = ( 0x000001 << 6 );
+        continue;
+      }
+    }
+
+    /* Compute the TOA brightness temperature for the desired band, in Kelvin,
+       and apply scaling of 10.0 (tied to lut->scale_factor_th).  Valid ranges
+       are set up in lut.c as well. */
+    rad = (rad_gain[cband] * (float)val[cband]) + rad_bias[cband];
+    temp = lut->K2[cband] / log(1.0 + (lut->K1[cband]/rad));
+    line_out[is] = (int16)(temp * 10.0 + 0.5);
+
+    /* Cap the output using the min/max values */
+    if (line_out[is] < lut->valid_range_th[0])
+      line_out[is] = lut->valid_range_th[0];
+    else if (line_out[is] > lut->valid_range_th[1])
+      line_out[is] = lut->valid_range_th[1];
   }  /* end for is */
 
   return true;

--- a/ledaps/ledapsSrc/src/lndcal/cal.h
+++ b/ledaps/ledapsSrc/src/lndcal/cal.h
@@ -6,37 +6,18 @@
 #include "lut.h"
 #include "input.h"
 static const int SATU_VAL[7]={255,255,255,255,255,255,255};
-static const int SATU_VAL6= 254;
-
-typedef struct {
-  bool first[NBAND_REFL_MAX];
-  unsigned char idn_min[NBAND_REFL_MAX];
-  unsigned char idn_max[NBAND_REFL_MAX];
-  float rad_min[NBAND_REFL_MAX];
-  float rad_max[NBAND_REFL_MAX];
-  float ref_min[NBAND_REFL_MAX];
-  float ref_max[NBAND_REFL_MAX];
-  int iref_min[NBAND_REFL_MAX];
-  int iref_max[NBAND_REFL_MAX];
-} Cal_stats_t;
-
-typedef struct {
-  bool first;
-  unsigned char idn_min;
-  unsigned char idn_max;
-  float rad_min;
-  float rad_max;
-  float temp_min;
-  float temp_max;
-  int itemp_min;
-  int itemp_max;
-} Cal_stats6_t;
+static const int SATU_VAL6=255;
+static const int SATU_LOW_VAL6=1;
 
 bool Cal(Param_t *param, Lut_t *lut, int iband, Input_t *input,
          unsigned char *line_in, int16 *line_in_sun_zen, int16 *line_out,
-         unsigned char *line_out_qa, Cal_stats_t *cal_stats, int iy);
+         unsigned char *line_out_qa, int iy);
 
 bool Cal6(Lut_t *lut, Input_t *input, unsigned char *line_in, 
-  int16 *line_out, unsigned char *line_out_qa, Cal_stats6_t *cal_stats, int iy);
+  int16 *line_out, unsigned char *line_out_qa, int iy);
+bool Cal6_combined(Lut_t *lut, Input_t *input, unsigned char *line_b6l,
+  unsigned char *line_b6h, int16 *line_out, unsigned char *line_out_qa,
+  int iy);
+
 
 #endif

--- a/ledaps/ledapsSrc/src/lndcal/input.h
+++ b/ledaps/ledapsSrc/src/lndcal/input.h
@@ -79,15 +79,23 @@ typedef struct {
   int iband_th;            /* Thermal Band number= (6) */
   float rad_gain[NBAND_REFL_MAX]; /* TOA radiance band gain */
   float rad_bias[NBAND_REFL_MAX]; /* TOA radiance band bias */
-  float rad_gain_th;           /* Thermal TOA radiance band gain */
-  float rad_bias_th;           /* Thermal TOA radiance band bias */
+  float rad_gain_th[2];    /* Thermal TOA radiance band gain (ETM+ B6L)
+                              [0] is TM band 6  OR
+                              [0] is ETM+ band 6L, [1] is ETM+ band 6H */
+  float rad_bias_th[2];    /* Thermal TOA radiance band bias
+                              [0] is TM band 6  OR
+                              [0] is ETM+ band 6L, [1] is ETM+ band 6H */
   bool use_toa_refl_consts;    /* Are the TOA reflectance gain/bias and K1/K2
                                   constants available? Same with earth-sun
                                   distance */
   float refl_gain[NBAND_REFL_MAX]; /* TOA reflectance band gain */
   float refl_bias[NBAND_REFL_MAX]; /* TOA reflectance band bias */
-  float k1_const;          /* K1 thermal constant */
-  float k2_const;          /* K2 thermal constant */
+  float k1_const[2];       /* K1 thermal constant
+                              [0] is TM band 6  OR
+                              [0] is ETM+ band 6L, [1] is ETM+ band 6H */
+  float k2_const[2];       /* K2 thermal constant
+                              [0] is TM band 6  OR
+                              [0] is ETM+ band 6L, [1] is ETM+ band 6H */
 } Input_meta_t;
 
 /* Structure for the 'input' data type */
@@ -96,12 +104,15 @@ typedef struct {
   Input_type_t file_type;  /* Type of the input image files */
   Input_meta_t meta;       /* Input metadata */
   int nband;               /* Number of input image files (bands) */
-  int nband_th;            /* Number of thermal input image files (0 or 1) */
+  int nband_th;            /* Number of thermal input image files (0, 1, 2) */
   Img_coord_int_t size;    /* Input file size */
   Img_coord_int_t size_th; /* Input (thermal) file size */
   char *file_name[NBAND_REFL_MAX];  
                            /* Name of the input image files */
-  char *file_name_th;      /* Name of the thermal input image files */
+  char *file_name_th[2];   /* Name of the thermal input image files
+                              [0] is TM band 6  OR
+                              [0] is ETM+ band 6L, [1] is ETM+ band 6H */
+
   char *file_name_sun_zen; /* Name of the represetative per-pixel solar zenith
                               file */
   bool open[NBAND_REFL_MAX]; 
@@ -111,7 +122,9 @@ typedef struct {
   bool open_th;            /* thermal open flag */
   bool open_sun_zen;       /* solar zenith open flag */
   FILE *fp_bin[NBAND_REFL_MAX];  /* File pointer for binary files */
-  FILE *fp_bin_th;         /* File pointer for thermal binary file */
+  FILE *fp_bin_th[2];      /* File pointer for thermal binary file;
+                              [0] is TM band 6  OR
+                              [0] is ETM+ band 6L, [1] is ETM+ band 6H */
   FILE *fp_bin_sun_zen;    /* File pointer for the representative per-pixel
                               array solar zenith band */
 } Input_t;
@@ -120,7 +133,8 @@ typedef struct {
 
 Input_t *OpenInput(Espa_internal_meta_t *metadata);
 bool GetInputLine(Input_t *this, int iband, int iline, unsigned char *line);
-bool GetInputLineTh(Input_t *this, int iline, unsigned char *line);
+bool GetInputLineTh(Input_t *this, int iline, unsigned char *line,
+  bool read_b6h, unsigned char *line_b6h);
 bool GetInputLineSunZen(Input_t *this, int iline, int16 *line);
 bool CloseInput(Input_t *this);
 bool FreeInput(Input_t *this);

--- a/ledaps/ledapsSrc/src/lndcal/lut.c
+++ b/ledaps/ledapsSrc/src/lndcal/lut.c
@@ -199,12 +199,12 @@ Lut_t *GetLut(Param_t *param, int nband, Input_t *input) {
           this->esun[ib] = esun_tm_4[iband];
           if ( ib==0 ){
             if (input_meta->use_toa_refl_consts) {
-              this->K1 = input_meta->k1_const;
-              this->K2 = input_meta->k2_const;
+              this->K1[0] = input_meta->k1_const[0];
+              this->K2[0] = input_meta->k2_const[0];
             }
             else {
-              this->K1 = K1_tm_4;
-              this->K2 = K2_tm_4;
+              this->K1[0] = K1_tm_4;
+              this->K2[0] = K2_tm_4;
             }
           }
         }
@@ -217,12 +217,12 @@ Lut_t *GetLut(Param_t *param, int nband, Input_t *input) {
           this->esun[ib] = esun_tm_5[iband];
           if ( ib==0 ){
             if (input_meta->use_toa_refl_consts) {
-              this->K1 = input_meta->k1_const;
-              this->K2 = input_meta->k2_const;
+              this->K1[0] = input_meta->k1_const[0];
+              this->K2[0] = input_meta->k2_const[0];
             }
             else {
-              this->K1 = K1_tm_5;
-              this->K2 = K2_tm_5;
+              this->K1[0] = K1_tm_5;
+              this->K2[0] = K2_tm_5;
             }
           }
         }
@@ -234,12 +234,16 @@ Lut_t *GetLut(Param_t *param, int nband, Input_t *input) {
         this->esun[ib] = esun_etm[iband];
         if ( ib==0 ){
           if (input_meta->use_toa_refl_consts) {
-            this->K1 = input_meta->k1_const;
-            this->K2 = input_meta->k2_const;
+            this->K1[0] = input_meta->k1_const[0];
+            this->K1[1] = input_meta->k1_const[1];
+            this->K2[0] = input_meta->k2_const[0];
+            this->K2[1] = input_meta->k2_const[1];
           }
           else {
-            this->K1 = K1_etm;
-            this->K2 = K2_etm;
+            this->K1[0] = K1_etm;
+            this->K1[1] = K1_etm;
+            this->K2[0] = K2_etm;
+            this->K2[1] = K2_etm;
           }
         }
         break;

--- a/ledaps/ledapsSrc/src/lndcal/lut.h
+++ b/ledaps/ledapsSrc/src/lndcal/lut.h
@@ -41,7 +41,6 @@
 #define LUT_H
 
 #include "lndcal.h"
-#include "lndcal.h"
 #include "input.h"
 #include "param.h"
 #include "bool.h"
@@ -59,8 +58,12 @@ typedef struct {
   float cos_sun_zen;           /* Cosine of the solar zenith angle          */
   float esun[NBAND_REFL_MAX];  /* Mean solar exoatmospheric irradiances     */ 
   float dsun2;                 /* Earth sun distance squared                */
-  float K1;                    /* K1 constant                               */
-  float K2;                    /* K2 constant                               */
+  float K1[2];                 /* K1 constant
+                                  [0] is TM band 6  OR
+                                  [0] is ETM+ band 6L, [1] is ETM+ band 6H  */
+  float K2[2];                 /* K2 constant
+                                  [0] is TM band 6  OR
+                                  [0] is ETM+ band 6L, [1] is ETM+ band 6H  */
   char* long_name_prefix_ref;  /* ref long name prefix (append band num)    */
   char* units_ref;             /* ref units                                 */
   int valid_range_ref[2];      /* ref valid range                           */

--- a/ledaps/ledapsSrc/src/lndcal/output.c
+++ b/ledaps/ledapsSrc/src/lndcal/output.c
@@ -72,8 +72,8 @@ Output_t *OpenOutput(Espa_internal_meta_t *in_meta, Input_t *input,
   /* Determine the number of output bands */
   if (!thermal)
     nband = input->nband;
-  else
-    nband = input->nband_th;
+  else  /* only one output thermal band (ETM+ uses a combination of 6H & 6L) */
+    nband = 1;
 
   /* QA will not be writen for MSS data or for thermal.  In the case of the
      thermal processing, the saturation QA band has already been generated as
@@ -191,8 +191,12 @@ Output_t *OpenOutput(Espa_internal_meta_t *in_meta, Input_t *input,
         bmeta[ib].scale_factor = lut->scale_factor_ref;
         bmeta[ib].scale_factor = lut->scale_factor_th;
         bmeta[ib].add_offset = lut->add_offset_th;
-        sprintf (bmeta[ib].long_name, "band %d top-of-atmosphere brightness "
-          "temperature", input->meta.iband_th);
+        if (input->nband_th == 1)
+          sprintf (bmeta[ib].long_name, "band %d top-of-atmosphere brightness "
+            "temperature", input->meta.iband_th);
+        else if (input->nband_th > 1)
+          sprintf (bmeta[ib].long_name, "combined band %d top-of-atmosphere "
+            "brightness temperature", input->meta.iband_th);
         strcpy (bmeta[ib].data_units, lut->units_th);
         bmeta[ib].valid_range[0] = (float) lut->valid_range_th[0];
         bmeta[ib].valid_range[1] = (float) lut->valid_range_th[1];

--- a/ledaps/ledapsSrc/src/lndpm/lndpm.h
+++ b/ledaps/ledapsSrc/src/lndpm/lndpm.h
@@ -35,7 +35,7 @@ NOTES:
 
 /* Defines */
 /* LEDAPS VERSION definitions */
-#define LEDAPS_VERSION "3.3.1"
+#define LEDAPS_VERSION "3.4.0"
 
 /* define useful constants */
 #define MAX_STRING_LENGTH 1000


### PR DESCRIPTION
Implemented the combined band 6 for BT.  Also removed the computation of the calibration statistics since they were never turned on in this code.  Furthermore, the high saturation for band 6H and band 6L will now just be applied for a value of 255 and no longer for a value of 254.