### PR TITLE
Fixed a bug for S2 fill pixels

### DIFF
--- a/lasrc/README.md
+++ b/lasrc/README.md
@@ -1,5 +1,5 @@
-## LaSRC Version 2.0.0 Release Notes
-Release Date: Sept. 2019
+## LaSRC Version 2.0.1 Release Notes
+Release Date: Jan. 2020
 
 ### Downloads
 LaSRC (Landsat Surface Reflectance Code) source code
@@ -11,7 +11,7 @@ LaSRC auxiliary files
     http://edclpdsftp.cr.usgs.gov/downloads/auxiliaries/lasrc_auxiliary/lasrc_aux.2013-2017.tar.gz
     http://edclpdsftp.cr.usgs.gov/downloads/auxiliaries/lasrc_auxiliary/MSILUT.tar.gz
 
-See git tag [lasrc-version_2.0.0]
+See git tag [lasrc-version_2.0.1]
 
 ### Installation
   * Install dependent libraries - ESPA product formatter (https://github.com/USGS-EROS/espa-product-formatter)
@@ -86,7 +86,6 @@ After compiling the product-formatter raw\_binary libraries and tools, the conve
 ### Product Guide
 
 ## Release Notes
-1. Modified the LaSRC executable to work with Sentinel-2 products.
-2. Added Sentinel-2 support to the do\_lasrc.py and surface\_reflectance.py scripts.
-3. Fixed a bug in the lat/long code when identifying the center of the pixel. This may have a slight affect on the Landsat-8 results.
-4. Copy the level-1 filenames for each of the reflectance bands to the level-2 bands for provenance of the old filenames, given that Sentinel-2 files are renamed in ESPA.
+1. Fixed a bug when masking fill values in the internal QA band.
+2. Modified the aerosol interpolation to not overwrite fill masks in the
+   ipflag. Fill values remain masked as fill.

--- a/lasrc/c_version/src/aero_interp.c
+++ b/lasrc/c_version/src/aero_interp.c
@@ -292,6 +292,7 @@ NOTES:
 void aerosol_interp_s2
 (
     int aero_window,   /* I: size of the aerosol window */
+    uint16 *qaband,    /* I: QA band for the input image, nlines x nsamps */
     uint8 *ipflag,     /* I/O: QA flag to assist with aerosol interpolation,
                                nlines x nsamps.  It is expected that the ipflag
                                values are computed for the UL of the aerosol
@@ -396,6 +397,14 @@ void aerosol_interp_s2
                 ipflag[curr_pix] = (1 << IPFLAG_INTERP_WINDOW);
         }  /* for samp */
     }  /* for line */
+
+    /* Clean up the ipflag for the fill pixels */
+    for (curr_pix = 0; curr_pix < nlines * nsamps; curr_pix++)
+    {
+        if (level1_qa_is_fill (qaband[curr_pix]))
+            ipflag[curr_pix] = (1 << IPFLAG_FILL);
+    }
+
 }
 
 

--- a/lasrc/c_version/src/aero_interp.h
+++ b/lasrc/c_version/src/aero_interp.h
@@ -33,6 +33,7 @@ void aerosol_interp_l8
 void aerosol_interp_s2
 (
     int aero_window,   /* I: size of the aerosol window */
+    uint16 *qaband,    /* I: QA band for the input image, nlines x nsamps */
     uint8 *ipflag,     /* I/O: QA flag to assist with aerosol interpolation,
                                nlines x nsamps.  It is expected that the ipflag
                                values are computed for the UL of the aerosol

--- a/lasrc/c_version/src/common.h
+++ b/lasrc/c_version/src/common.h
@@ -14,7 +14,7 @@ typedef char byte;
 #endif
 
 /* Surface reflectance version */
-#define SR_VERSION "2.0.0"
+#define SR_VERSION "2.0.1"
 
 /* Define the default aerosol value */
 #define DEFAULT_AERO 0.05

--- a/lasrc/c_version/src/compute_s2_refl.c
+++ b/lasrc/c_version/src/compute_s2_refl.c
@@ -583,8 +583,9 @@ int compute_s2_sr_refl
 
                 }
                 else
-                { /* fill value */
-                    qaband[curr_pix] |= ESPA_L1_DESIGNATED_FILL_BIT;
+                { /* fill value - if any of the bands are fill this pixel is
+                     masked as fill in the QA band */
+                    qaband[curr_pix] |= (1 << ESPA_L1_DESIGNATED_FILL_BIT);
                     sband[ib][curr_pix] = FILL_VALUE;
                 }
             }  /* end for j */
@@ -1230,14 +1231,14 @@ int compute_s2_sr_refl
     mytime = time(NULL);
     printf ("Interpolating the aerosol values in the NxN windows %s\n",
         ctime(&mytime)); fflush(stdout);
-    aerosol_interp_s2 (S2_AERO_WINDOW, ipflag, taero, nlines, nsamps);
+    aerosol_interp_s2 (S2_AERO_WINDOW, qaband, ipflag, taero, nlines, nsamps);
 
     /* Use the UL corner of the aerosol windows to interpolate the teps values
        (angstrom coefficient) */
     mytime = time(NULL);
     printf ("Interpolating the teps values in the NxN windows %s\n",
         ctime(&mytime)); fflush(stdout);
-    aerosol_interp_s2 (S2_AERO_WINDOW, ipflag, teps, nlines, nsamps);
+    aerosol_interp_s2 (S2_AERO_WINDOW, qaband, ipflag, teps, nlines, nsamps);
 
 #ifdef WRITE_TAERO
     /* Write the ipflag values for comparison with other algorithms */

--- a/lasrc/c_version/src/lasrc.c
+++ b/lasrc/c_version/src/lasrc.c
@@ -277,7 +277,7 @@ int main (int argc, char *argv[])
     {
         if (get_input_ppa_lines (input, 0, nlines, sza) != SUCCESS)
         {
-            sprintf (errmsg, "Reading per-pixel solar and view angle bands");
+            sprintf (errmsg, "Reading per-pixel solar angle bands");
             error_handler (true, FUNC_NAME, errmsg);
             exit (ERROR);
         }


### PR DESCRIPTION
Masking of the Sentinel-2 fill pixels was fixed, both in the identification of fill as well as making sure aerosol interpolation didn't overwrite fill masks.